### PR TITLE
prototype argparse2tool integration

### DIFF
--- a/bioconda_cli/main.py
+++ b/bioconda_cli/main.py
@@ -1,8 +1,8 @@
 """
 CLI for executing aCLImatise over Bioconda
 """
-from multiprocessing import Pool
 import subprocess
+from multiprocessing import Pool
 
 from acclimatise import CwlGenerator, WdlGenerator, WrapperGenerator, YmlGenerator
 
@@ -121,7 +121,7 @@ def list_packages(test=False, last_spec=None, verbose=True, filter_r=False):
         if filter_r and (key.startswith("r-") or key.startswith("bioconductor-")):
             continue
         latest_version = max(versions, key=lambda v: parse(v["version"]))
-        
+
         py = False
         for d in latest_version["depends"]:
             if "python" in d:
@@ -164,38 +164,39 @@ def commands_from_package(
     with log_around("Acclimatising {}".format(package), verbose=verbose):
         dir = "/tmp/bioconda_cli/%s" % versioned_package
         if 1:
-        #with tempfile.TemporaryDirectory() as dir:
+            # with tempfile.TemporaryDirectory() as dir:
             install_package(
                 versioned_package, dir, out_subdir, verbose, exit_on_failure
             )
             with activate_env(pathlib.Path(dir)):
                 new_exes = get_package_binaries(package, version)
                 # Acclimatise each new executable
-#                 if len(new_exes) == 0:
-#                     ctx_print("Package has no executables. Skipping.", verbose)
-#                 for exe in new_exes:
-#                     print("proecessing exe %s" % exe)
-#                     acclimatise_exe(
-#                         exe,
-#                         out_subdir,
-#                         verbose=verbose,
-#                         exit_on_failure=exit_on_failure,
-#                         run_kwargs={"cwd": dir},
-#                     )
+            #                 if len(new_exes) == 0:
+            #                     ctx_print("Package has no executables. Skipping.", verbose)
+            #                 for exe in new_exes:
+            #                     print("proecessing exe %s" % exe)
+            #                     acclimatise_exe(
+            #                         exe,
+            #                         out_subdir,
+            #                         verbose=verbose,
+            #                         exit_on_failure=exit_on_failure,
+            #                         run_kwargs={"cwd": dir},
+            #                     )
             for exe in new_exes:
                 cmd = """. /home/berntm/miniconda3/etc/profile.d/conda.sh &&
 conda activate %s &&
 PYTHONPATH="$(argparse2tool)" %s --generate_galaxy_xml
-""" % (dir, exe)
+""" % (
+                    dir,
+                    exe,
+                )
                 proc = subprocess.run(cmd, stdout=subprocess.PIPE, shell=True)
                 if proc.returncode:
                     print("failed for %s %s" % (exe, proc))
                     continue
-                ofn = pathlib.Path("%s-%s.xml" % (package,
-                                                  os.path.basename(exe)))
+                ofn = pathlib.Path("%s-%s.xml" % (package, os.path.basename(exe)))
                 with open(out_subdir / ofn, "wb") as ofh:
                     ofh.write(proc.stdout)
-
 
     flush()
 

--- a/bioconda_cli/util.py
+++ b/bioconda_cli/util.py
@@ -207,7 +207,7 @@ def acclimatise_exe(
     with log_around("Exploring {}".format(exe.name), verbose):
         try:
             # Briefly cd into the temp directory, so we don't fill up the cwd with junk
-            cmd = explore_command([exe.name], run_kwargs={"check": False, **run_kwargs})
+            cmd = explore_command([exe.name], run_kwargs={**run_kwargs})
 
             # Dump a YAML version of the tool
             with (out_dir / exe.name).with_suffix(".yml").open("w") as out_fp:

--- a/bioconda_cli/util.py
+++ b/bioconda_cli/util.py
@@ -90,13 +90,16 @@ def get_package_binaries(package, version) -> List[pathlib.Path]:
     # The binaries in a given package are listed in the files key of the metadata file
     with metadata[0].open() as fp:
         parsed = json.load(fp)
-        # Only return binaries, not just any package file. 
+        # Only return binaries, not just any package file.
         # Their actual location is relative to the prefix
         # Filter out .PACKAGENAME-post-link.sh and .PACKAGENAME-pre-unlink.sh
-        return [env_path / f for f in parsed["files"] if 
-                f.startswith("bin/") and
-                not f.endswith(".%s-post-link.sh" % package) and
-                not f.endswith(".%s-pre-unlink.sh" % package)]
+        return [
+            env_path / f
+            for f in parsed["files"]
+            if f.startswith("bin/")
+            and not f.endswith(".%s-post-link.sh" % package)
+            and not f.endswith(".%s-pre-unlink.sh" % package)
+        ]
 
 
 @contextmanager

--- a/bioconda_cli/util.py
+++ b/bioconda_cli/util.py
@@ -90,8 +90,13 @@ def get_package_binaries(package, version) -> List[pathlib.Path]:
     # The binaries in a given package are listed in the files key of the metadata file
     with metadata[0].open() as fp:
         parsed = json.load(fp)
-        # Only return binaries, not just any package file. Their actual location is relative to the prefix
-        return [env_path / f for f in parsed["files"] if f.startswith("bin/")]
+        # Only return binaries, not just any package file. 
+        # Their actual location is relative to the prefix
+        # Filter out .PACKAGENAME-post-link.sh and .PACKAGENAME-pre-unlink.sh
+        return [env_path / f for f in parsed["files"] if 
+                f.startswith("bin/") and
+                not f.endswith(".%s-post-link.sh" % package) and
+                not f.endswith(".%s-pre-unlink.sh" % package)]
 
 
 @contextmanager
@@ -151,6 +156,10 @@ def install_package(
     :param exit:
     :return:
     """
+    if os.path.exists(env_dir):
+        return
+    else:
+        os.makedirs(env_dir)
     # Create an empty environment
     run_command(
         "create", "--yes", "--quiet", "--prefix", env_dir,
@@ -161,7 +170,7 @@ def install_package(
         solver = Solver(
             str(env_dir),
             ["bioconda", "conda-forge", "r", "main", "free"],
-            specs_to_add=[versioned_package],
+            specs_to_add=[versioned_package, "argparse2tool"],
         )
         try:
             transaction = solver.solve_for_transaction()


### PR DESCRIPTION
quite hacky .. so far

- filter for python packages. I'm not sure if python itself of a package containing the string "python" is the best possible filter.  Maybe checking for the `noarch: python` info is better (or might be done in addition)
- I install argparse2tool into the same environment as the actual package
  - if we go for containers one day there should be another solution
- to be able to test faster I install the environments into a fixed location (then `conda create` is only called for the first execution)
