### PR TITLE
Simplify outputs

### DIFF
--- a/aclimatise_automation/__init__.py
+++ b/aclimatise_automation/__init__.py
@@ -170,7 +170,7 @@ def generate_wrapper(
 
     logger.info("Converting...")
     with command.open() as fp:
-        cmd = yaml.load(fp)
+        cmd: Command = yaml.load(fp)
 
     if output_dir:
         output_path = pathlib.Path(output_dir) / command.parent.relative_to(command_dir)
@@ -194,7 +194,9 @@ def generate_wrapper(
             for gen in generators:
                 path = output_path / (cmd.as_filename + gen.suffix)
                 gen.save_to_file(cmd, path)
-                logger.info("Converted to {}".format(gen.suffix))
+                logger.info(
+                    "{} converted to {}".format(" ".join(cmd.command), gen.suffix)
+                )
     except Exception as e:
         logger.error(handle_exception())
 

--- a/aclimatise_automation/util.py
+++ b/aclimatise_automation/util.py
@@ -130,7 +130,11 @@ def aclimatise_exe(
     try:
         exec = DockerExecutor(container, timeout=10)
         cmd = explore_command(cmd=[exe], executor=exec)
-        # Dump a YAML version of the tool
-        exhaust(gen.generate_tree(cmd, out_dir))
+        path = out_dir / (cmd.as_filename + ".yml")
+        # Rather than writing out the whole tree, which has redundant information, we instead take the top level command
+        # which contains the entire tree, and serialize that
+        gen.save_to_file(cmd, path)
     except Exception as e:
         handle_exception()
+
+    logger.info("Successfully written to YAML".format(exe))


### PR DESCRIPTION
When aCLImatising, only output one file per command tree. When converting, don't output parent commands